### PR TITLE
Fix proto path imports

### DIFF
--- a/utilities/dummy_client.py
+++ b/utilities/dummy_client.py
@@ -2,7 +2,12 @@ import grpc
 
 # Import the generated classes
 import sys
-sys.path.append('../proto')  # Add proto folder to Python path
+import os
+# Add the generated protobuf modules relative to this file so that the client
+# can be executed from any location.
+proto_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'proto'))
+if proto_dir not in sys.path:
+    sys.path.insert(0, proto_dir)
 import dummy_pb2
 import dummy_pb2_grpc
 

--- a/utilities/dummy_server.py
+++ b/utilities/dummy_server.py
@@ -4,7 +4,11 @@ import time
 
 # Import the generated classes
 import sys
-sys.path.append('../proto')  # Add proto folder to Python path
+import os
+# Ensure imports work regardless of where this server is launched from.
+proto_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'proto'))
+if proto_dir not in sys.path:
+    sys.path.insert(0, proto_dir)
 import dummy_pb2
 import dummy_pb2_grpc
 

--- a/utilities/nf_client.py
+++ b/utilities/nf_client.py
@@ -4,7 +4,14 @@ import datetime
 
 # Import the generated classes
 import sys
-sys.path.append('../proto') # Add proto folder to Python path
+import os
+# Ensure the generated protobuf modules can be imported regardless of the
+# current working directory.  Compute the path to the ``proto`` directory
+# relative to this file and add it to ``sys.path`` only if it's not already
+# present.
+proto_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'proto'))
+if proto_dir not in sys.path:
+    sys.path.insert(0, proto_dir)
 import nf_ai_comms_pb2
 import nf_ai_comms_pb2_grpc
 

--- a/utilities/nf_server.py
+++ b/utilities/nf_server.py
@@ -11,7 +11,12 @@ def app_log(message):
 
 # Import the generated classes
 import sys
-sys.path.append('../proto') # Add proto folder to Python path
+import os
+# Add the generated protobuf modules to the import path relative to this file so
+# the server can be started from any working directory.
+proto_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'proto'))
+if proto_dir not in sys.path:
+    sys.path.insert(0, proto_dir)
 import nf_ai_comms_pb2
 import nf_ai_comms_pb2_grpc
 


### PR DESCRIPTION
## Summary
- fix python utilities to locate the `proto` directory relative to file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_683cc77ca42483319e6afea9fe7af53b